### PR TITLE
refactor: use Auth V2 API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,6 @@
 import axios from 'axios';
 import { createHmac } from 'crypto';
 
-export enum AuthLevel {
-	Unverified,
-	Applicant,
-	Attendee,
-	Volunteer,
-	Organiser
-}
-
 export interface APIDiscordResource {
 	name: string;
 	discordId: string;
@@ -17,7 +9,6 @@ export interface APIDiscordResource {
 export interface APIUser {
 	authId: string;
 	discordId: string;
-	authLevel: AuthLevel;
 	email: string;
 	name: string;
 	team?: string;


### PR DESCRIPTION
Luckily there aren't too many breakages here, they will come with the `hs_discord_bot` instead :sweat_smile: 

Related to https://github.com/unicsmcr/hs_discord_bot_api/pull/18